### PR TITLE
Create gcs.tf

### DIFF
--- a/code/build/gcs.tf
+++ b/code/build/gcs.tf
@@ -1,0 +1,21 @@
+provider "google" {
+  project = "qwiklabs-gcp-01-48398af090d8"
+  region  = "us-central1"
+}
+
+resource "google_storage_bucket" "example" {
+  name          = "demo-${random_id.rand_suffix.hex}"
+  location      = "us-central1"
+  force_destroy = true
+
+  uniform_bucket_level_access = false
+  public_access_prevention = "enforced"
+}
+
+resource "random_id" "rand_suffix" {
+  byte_length = 4
+}
+
+output "bucket_name" {
+  value = google_storage_bucket.example.name
+}


### PR DESCRIPTION
This pull request introduces a new Terraform configuration to provision a Google Cloud Storage (GCS) bucket in the `us-central1` region. The configuration includes secure settings and outputs the created bucket's name.

Infrastructure provisioning:

* Added a `google` provider configuration specifying the project and region for resource deployment.
* Defined a `google_storage_bucket` resource with enforced public access prevention, non-uniform bucket-level access, and automatic destruction enabled.
* Introduced a `random_id` resource to generate a unique suffix for the bucket name, ensuring uniqueness across deployments.

Outputs:

* Added an output variable to expose the created bucket's name after deployment.